### PR TITLE
Pequeñas modificaciones tras ejecutar la demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@ This demo show how to implement a continuous delivery pipeline supporting Oracle
 - Internet connection (required for gradle to be able to connect to maven central and download libs)
 - JDK 1.8
 - gradle
-- SQLcl version 20.4. This is the version comming inside SQL Developer version 20.4. NOTE: Version 21 has a bug avoiding to complete the demo
+- SQLcl version 20.4. This is the version comming inside SQL Developer version 20.4. NOTE: Version 21 has a bug avoiding to complete the demo (PATH variable needs to be updated to include sqlcl bin directory)
 - git
 
 # Setting up the demo environment

--- a/postman/Springboot Sample App.postman_collection.json
+++ b/postman/Springboot Sample App.postman_collection.json
@@ -185,12 +185,12 @@
 				"method": "GET",
 				"header": [],
 				"url": {
-					"raw": "{{origin}}/productCount",
+					"raw": "{{origin}}/greeting",
 					"host": [
 						"{{origin}}"
 					],
 					"path": [
-						"productCount"
+						"greeting"
 					]
 				}
 			},

--- a/scripts/dev-publish-version.sh
+++ b/scripts/dev-publish-version.sh
@@ -15,8 +15,7 @@ if [ -z "$1" ]
 		echo "Use: $0 versionlabel"
 		exit 1
 	else
-		VERSION="$1"
-		VERSION=${VERSION^^}
+		VERSION=$(echo "$1" | tr [':lower:'] [':upper:'])
 fi
 
 CURRENT_ENV=${PWD##*/}

--- a/scripts/dev-publish-version.sh
+++ b/scripts/dev-publish-version.sh
@@ -30,7 +30,7 @@ fi
 source setenv.sh
 
 # Generate Liquibase controller and schema
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp<<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE}<<-EOF
 set echo on
 CD database/liquibase
 LB gencontrolfile

--- a/scripts/initialize.sh
+++ b/scripts/initialize.sh
@@ -39,16 +39,13 @@ cd "${CURDIR}"
 cp -r ../v0/setenv.sh ../environments/pre
 chmod +x ../environments/pre/setenv.sh
 cd ../environments/pre
-echo "TNS_ADMIN=${TNS_ADMIN}" >.env
-echo "DB_USER=${DEV_USER}" >>.env
-echo "DB_PASSWORD=${DEV_PASSWORD}" >>.env
-echo "DB_URL=${DB_URL}" >>.env
 
 ## Setpre  environment variables 
 echo "TNS_ADMIN=${TNS_ADMIN}" >.env
 echo "DB_USER=${PRE_USER}" >>.env
 echo "DB_PASSWORD=${PRE_PASSWORD}" >>.env
 echo "DB_URL=${DB_URL}" >>.env
+echo "TNS_SERVICE=${TNS_SERVICE}" >>.env
 
 ## Set dev environment cloning from origin
 cd ..
@@ -62,6 +59,7 @@ echo "TNS_ADMIN=${TNS_ADMIN}" >.env
 echo "DB_USER=${DEV_USER}" >>.env
 echo "DB_PASSWORD=${DEV_PASSWORD}" >>.env
 echo "DB_URL=${DB_URL}" >>.env
+echo "TNS_SERVICE=${TNS_SERVICE}" >>.env
 
 
 # Deploy version v0 of application to dev environment

--- a/scripts/pre-deploy-version-for-all.sh
+++ b/scripts/pre-deploy-version-for-all.sh
@@ -27,7 +27,7 @@ echo "=============================================="
 echo "Deploy last version for everybody"  
 
 # Get last edition
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp >>pre-rollback-version.log <<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE} >>pre-rollback-version.log <<-EOF
 SET PAGES 0
 SET FEEDBACK OFF
 SET TERM OFF
@@ -48,7 +48,7 @@ LAST_VERSION=$(echo $LAST_EDITION|sed 's/EDITION_//g')
 echo "Deploy last version ${LAST_VERSION} for everybody using edition ${LAST_EDITION}"  
 
 # Update schema based in Liquibase controller
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp <<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE} <<-EOF
 SET ECHO ON
 ALTER DATABASE DEFAULT EDITION = $LAST_EDITION;
 QUIT

--- a/scripts/pre-deploy-version-in-test.sh
+++ b/scripts/pre-deploy-version-in-test.sh
@@ -35,7 +35,7 @@ echo "=============================================="
 echo "Deploy version in test on $(date)"  
 
 # Get last edition
-sql -S ${DB_USER}/${DB_PASSWORD}@lbtest_tp >>pre-rollback-version.log <<-EOF
+sql -S ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE} >>pre-rollback-version.log <<-EOF
 -- Exit on error
 WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK;
 SET PAGES 0
@@ -67,7 +67,7 @@ git push -f --tags
 
 # Create EDITION
 echo "Creating edition ${NEW_EDITION}"
-sql -S ${DB_USER}/${DB_PASSWORD}@lbtest_tp  <<-EOF
+sql -S ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE}  <<-EOF
 -- Exit on error
 WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK;
 SET PAGES 0
@@ -86,7 +86,7 @@ EOF
 
 # Update schema based in Liquibase controller
 echo "Updating schema (DDL and code)"
-sql -S ${DB_USER}/${DB_PASSWORD}@lbtest_tp  <<-EOF
+sql -S ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE}  <<-EOF
 -- Exit on error
 WHENEVER SQLERROR EXIT SQL.SQLCODE ROLLBACK;
 SET PAGES 0

--- a/scripts/pre-deploy-version-in-test.sh
+++ b/scripts/pre-deploy-version-in-test.sh
@@ -17,8 +17,7 @@ if [ -z "$1" ]
 		echo "Use: $0 versionlabel"
 		exit 1
 	else
-		VERSION="$1"
-		VERSION=${VERSION^^}
+		VERSION=$(echo "$1" | tr [':lower:'] [':upper:'])
 fi
 
 CURRENT_ENV=${PWD##*/}

--- a/scripts/pre-rollback-version.sh
+++ b/scripts/pre-rollback-version.sh
@@ -29,7 +29,7 @@ echo "=============================================="
 echo "Rolling back last version on $(date)"
 
 # Get last edition
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp  <<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE}  <<-EOF
 SET PAGES 0
 SET FEEDBACK OFF
 SET TERM OFF
@@ -49,7 +49,7 @@ LAST_EDITION=$(cat $TEMPFILE && rm $TEMPFILE)
 LAST_VERSION=$(echo $LAST_EDITION|sed 's/EDITION_//g')
 
 # Get previous edition
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp <<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE} <<-EOF
 SET PAGES 0
 SET FEEDBACK OFF
 SET TERM OFF
@@ -81,7 +81,7 @@ echo "Returning to version ${PREVIOUS_VERSION}"
 # Rolling back: EDITION, LIQUIBASE (SCHEMA) AND GIT
 ## Return to previous edition and drop last edition
 echo "Replace current edition with $PREVIOUS_EDITION"  
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp  <<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE}  <<-EOF
 SET ECHO ON
 ALTER DATABASE DEFAULT EDITION = $PREVIOUS_EDITION;
 ALTER SESSION SET EDITION = $PREVIOUS_EDITION;
@@ -90,7 +90,7 @@ QUIT
 EOF
 
 ## Get last tag count
-sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp <<-EOF
+sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE} <<-EOF
 SET PAGES 0
 SET FEEDBACK OFF
 SET TERM OFF
@@ -114,7 +114,7 @@ if [ ${COUNTLASTTAG} -eq 0 ]
 	else
 		## Rolling back schema based in Liquibase controller
 		echo "Rolling back $COUNTLASTTAG updates from version $LAST_VERSION"
-		sql ${DB_USER}/${DB_PASSWORD}@lbtest_tp <<-EOF
+		sql ${DB_USER}/${DB_PASSWORD}@${TNS_SERVICE} <<-EOF
 		set echo on
 		cd database/liquibase
 		lb rollback -changelog controller.xml -log -count $COUNTLASTTAG

--- a/v0/setenv.sh
+++ b/v0/setenv.sh
@@ -4,6 +4,7 @@ export DB_USER=$DB_USER
 export DB_PASSWORD=$DB_PASSWORD
 export DB_URL=$DB_URL
 export TNS_ADMIN=$TNS_ADMIN
+export TNS_SERVICE=$TNS_SERVICE
 
 
 


### PR DESCRIPTION
Los commits de la rama feat-cmolina incluyen:

- Aclaración de que el directorio bin de sqlcl tiene que estar en el PATH
- ${VERSION^^} para pasar la variable a mayúsculas no funcionaba con bash 3.2 en mac. He visto algún link que está soportado a partir de versión 4. Lo he substituido por una llamada a "tr"
- El get greeting de postman apuntaba a productCount
- La entrada TNS lbtest_tp estaba hardcodeada en algunas partes del código. La he substituido por la variable TNS_SERVICE y he propagado la variable TNS_SERVICE a los ficheros .env de dev y pre